### PR TITLE
Move to a faster polylines decoder

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ platforms :ruby do
 end
 
 gem 'activerecord-postgis-adapter', '~> 3.1.4'
-gem 'polylines'
+gem 'fast-polylines', '~> 1.0'
 
 # Authentication
 gem 'devise', '~> 3.5.10'

--- a/lib/osrm_5_route_section_processor.rb
+++ b/lib/osrm_5_route_section_processor.rb
@@ -37,7 +37,7 @@ class Osrm_5_RouteSectionProcessor
       routes["routes"].map do |legs|
         legs["legs"].map do |steps|
           steps["steps"].map do |geometry|
-            current_points = Polylines::Decoder.decode_polyline(geometry["geometry"], 1e5).map do |point|
+            current_points = FastPolylines::Decoder.decode(geometry["geometry"], 1e5).map do |point|
               GeoRuby::SimpleFeatures::Point.from_x_y(point[1], point[0], 4326)
             end
             decoded_geometry.nil? ? decoded_geometry = current_points : decoded_geometry.concat(current_points)

--- a/lib/osrm_route_section_processor.rb
+++ b/lib/osrm_route_section_processor.rb
@@ -33,7 +33,7 @@ class OsrmRouteSectionProcessor
 
     geometry = JSON.parse(response.read.to_s)['route_geometry']
     if geometry
-      decoded_geometry = Polylines::Decoder.decode_polyline(geometry, 1e6).map do |point|
+      decoded_geometry = FastPolylines::Decoder.decode(geometry, 1e6).map do |point|
         GeoRuby::SimpleFeatures::Point.from_x_y(point[1], point[0], 4326)
       end
 


### PR DESCRIPTION
Moving to a 10x faster gem to decode polylines in OSRM processors (see [README](https://github.com/klaxit/fast-polylines/blob/master/README.md) for the benchmark).

**Disclaimer**: I am the author of this gem @klaxit. We have been using this gem in production to decode 1M+ polylines a day for more than 6 months.